### PR TITLE
feat(footer): show per-session cache stats instead of cumulative totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ On Pi 0.79.7 and newer, `pi update` updates Pi itself only. To update installed 
 | `PI_CACHE_OPTIMIZER_NO_OPENAI_CACHE_KEY=1` | Disable the OpenAI-compatible `prompt_cache_key` fallback. Preferred explicit opt-out. |
 | `PI_CACHE_OPTIMIZER_OPENAI_CACHE_KEY=0` | Disable the same fallback via the legacy inverse switch. Values `0`, `false`, `no`, or `off` disable it. |
 
+## Footer cache stats mode
+
+`PI_CACHE_OPTIMIZER_FOOTER_MODE` selects which counters the footer shows:
+
+| Value | Effect |
+|---|---|
+| `session` (default) | Show only the **current session's** counters; a fresh session starts at `0/0` and accumulates only its own requests. The same session reloaded after an extension reload keeps its counters. |
+| `total` | Show **restart-persistent cumulative** counters across all sessions (the original behavior). |
+
 ## OpenAI-compatible proxy setup
 
 Third-party `openai-completions` proxies (LiteLLM / OneAPI / NewAPI / OpenRouter-like channels) often route one session across multiple upstream backends. That splits provider-side prompt caches.

--- a/index.ts
+++ b/index.ts
@@ -7072,10 +7072,13 @@ export default function (pi: ExtensionAPI) {
     }
 
     if (adapter) {
-      // Display provider/model cumulative stats. A model that has never
-      // been used locally shows 0/0. The message_end hook updates both the
-      // current session bucket and this restart-persistent totals bucket.
-      const stats = displayModel ? cacheStatsTotalsByModel[modelKey(displayModel)] : undefined;
+      // Display current-session stats. A fresh session starts at 0/0 and
+      // only accumulates this session's traffic; message_end updates the
+      // per-session bucket. Cross-session totals stay in the totals bucket
+      // (still persisted) but are no longer shown in the footer here.
+      const stats = displayModel && currentSessionHashSet
+        ? cacheStatsByModel[makeSessionModelKey(currentSessionHash, displayModel.provider, displayModel.id)]
+        : undefined;
       const statsText = formatCacheStats(adapter, stats ?? emptyCacheStats());
       statusText = runtimeOptimizerEnabled ? statsText : `Cache Optimizer disabled · ${statsText}`;
     }

--- a/index.ts
+++ b/index.ts
@@ -101,6 +101,7 @@ const NO_OPENAI_CACHE_KEY_ENV = "PI_CACHE_OPTIMIZER_NO_OPENAI_CACHE_KEY";
 const OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH = 64;
 const NO_SKILL_COMPRESSION_ENV = "PI_CACHE_OPTIMIZER_NO_SKILL_COMPRESSION";
 const NO_PROMPT_REWRITE_ENV = "PI_CACHE_OPTIMIZER_NO_PROMPT_REWRITE";
+const FOOTER_MODE_ENV = "PI_CACHE_OPTIMIZER_FOOTER_MODE";
 const PI_ROUTING_REGISTRY_SYMBOL = Symbol.for("pi.routing.registry.v1");
 const PI_CACHE_HINTS_SYMBOL = Symbol.for("pi.cache.hints.v1");
 const PI_CACHE_HINTS_OWNER_SYMBOL = Symbol.for("pi.cache.optimizer.hints-owner.v1");
@@ -1131,6 +1132,12 @@ function isEnabledEnv(value: string | undefined): boolean {
   const normalized = value.trim().toLowerCase();
   return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
+
+function footerStatsMode(env: MutableEnv = process.env): "session" | "total" {
+  const raw = (env[FOOTER_MODE_ENV] ?? "").trim().toLowerCase();
+  return raw === "total" ? "total" : "session";
+}
+
 
 function isDisabledEnv(value: string | undefined): boolean {
   if (!value) return false;
@@ -7072,13 +7079,17 @@ export default function (pi: ExtensionAPI) {
     }
 
     if (adapter) {
-      // Display current-session stats. A fresh session starts at 0/0 and
-      // only accumulates this session's traffic; message_end updates the
-      // per-session bucket. Cross-session totals stay in the totals bucket
-      // (still persisted) but are no longer shown in the footer here.
-      const stats = displayModel && currentSessionHashSet
-        ? cacheStatsByModel[makeSessionModelKey(currentSessionHash, displayModel.provider, displayModel.id)]
-        : undefined;
+      // Footer cache-stat mode: "session" (default) shows only the current
+      // session's counters (a fresh session starts at 0/0); "total" shows the
+      // restart-persistent cumulative counters (original behavior).
+      // Controlled via PI_CACHE_OPTIMIZER_FOOTER_MODE.
+      const mode = footerStatsMode();
+      const stats =
+        mode === "total"
+          ? displayModel ? cacheStatsTotalsByModel[modelKey(displayModel)] : undefined
+          : displayModel && currentSessionHashSet
+            ? cacheStatsByModel[makeSessionModelKey(currentSessionHash, displayModel.provider, displayModel.id)]
+            : undefined;
       const statsText = formatCacheStats(adapter, stats ?? emptyCacheStats());
       statusText = runtimeOptimizerEnabled ? statsText : `Cache Optimizer disabled · ${statsText}`;
     }


### PR DESCRIPTION
## Motivation

The footer currently reads the **restart-persistent totals bucket** (`totalsByModel`), so a brand-new Pi session immediately shows large cumulative counters summed from every previous session (e.g. `DS cache 477/483 · 76M/77M tok`). Two problems:

1. **It never reflects the current session.** After a backend/vLLM restart the prefix cache is cold — the session is actually miss-heavy — but the cumulative 99% hides it.
2. **It doesn't reset on a new session**, which makes the number look stale/confusing in a fresh conversation.

## Change

The extension **already keeps a per-session bucket** (`cacheStatsByModel`, keyed `<sessionHash>:<provider>/<model>`) updated on every `message_end` alongside the totals bucket — it's just not used by the normal footer path. This PR switches the regular adapter branch to it, using the same `makeSessionModelKey` lookup that `buildExactRouterStatusEntry` already uses for router-model restoration (so the two paths become consistent).

Behavior:

- A **fresh session starts at `0/0 · 0M/0M`** and only accumulates its own traffic.
- A **reloaded same-session** keeps its counters (the session bucket is persisted).
- The totals bucket is **untouched**: still populated and persisted for `/cache-optimizer stats`; only the footer read changes. No data migration needed.

## Verification

- The touched region type-checks in scope (both buckets, `currentSessionHash(Set)`, and `makeSessionModelKey` are all visible in `publishStatus`); no syntax errors.
- Tested live: after a fresh session the footer reads `0/0` and grows only with the session's own requests; same-session reload restores the per-session counters.

## Notes for maintainer

This is a deliberate behavior change (the totals view is intentionally cross-restart per the README). If you'd rather keep the cumulative footer by default, an easy follow-up is a config toggle (`session` vs `total`) — happy to add it if you prefer that direction.
