### PR TITLE
fix: include subagent traffic in footer cache stats

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3936,6 +3936,72 @@ function mergeCacheStatsForTotal(existing: CacheStats | undefined, incoming: Cac
   addCacheStatsTotals(existing, incoming);
   return existing;
 }
+// ── Process-wide live totals (parent + subagent aggregation) ─────────
+// All extension instances (main session + pi-minions subagents) run in the
+// same Node.js process. Each session's message_end is handled by its OWN
+// instance, so per-instance maps never see other sessions' traffic. To make
+// the main footer's "total" mode reflect subagent cache usage too, every
+// instance folds its usage into a shared process-global sink keyed by
+// provider/model. The parent instance resets+seeds the sink from persisted
+// totals at session_start, so the displayed baseline stays authoritative
+// across reloads (no double counting) while live subagent events accumulate.
+const LIVE_TOTALS_GLOBAL_KEY = "__piCacheOptimizerLiveTotals__";
+
+function liveTotalsSink(): Record<string, CacheStats> {
+  const g = globalThis as Record<string, unknown>;
+  let sink = g[LIVE_TOTALS_GLOBAL_KEY] as Record<string, CacheStats> | undefined;
+  if (!sink) {
+    sink = {};
+    g[LIVE_TOTALS_GLOBAL_KEY] = sink;
+  }
+  return sink;
+}
+
+/** True when this extension instance belongs to the top-level interactive
+ *  session (vs. a pi-minions subagent session created in-process). */
+function isParentSessionInstance(ctx: { sessionManager?: { getSessionId(): string | undefined } }): boolean {
+  const sid = ctx.sessionManager?.getSessionId();
+  return !!sid && sid === process.env.PI_SESSION_ID;
+}
+
+/** Reset the shared sink and re-seed it from the persisted cumulative totals.
+ *  Called by the parent instance at session_start/restore so the displayed
+ *  baseline equals on-disk totals and live events add exactly once. */
+function seedLiveTotalsSink(totalsByModel: Record<string, CacheStats>): void {
+  const sink = liveTotalsSink();
+  for (const key of Object.keys(sink)) delete sink[key];
+  for (const [key, stats] of Object.entries(totalsByModel)) sink[key] = cloneCacheStats(stats);
+}
+
+/** Fold one message's usage into the shared sink (called by every instance). */
+function addUsageToLiveTotals(model: ModelIdentity, usage: UsageSnapshot): void {
+  const key = modelKey(model);
+  const sink = liveTotalsSink();
+  const existing = sink[key];
+  const incoming = emptyCacheStats();
+  addUsageToCacheStats(incoming, usage);
+  sink[key] = mergeCacheStatsForTotal(existing, incoming);
+}
+
+/** Roll the shared sink's day buckets over (mirrors totalsByModel). */
+function rollOverLiveTotalsSink(): void {
+  const day = currentLocalDay();
+  const sink = liveTotalsSink();
+  for (const key of Object.keys(sink)) {
+    const stats = sink[key];
+    if (stats && stats.day !== day) sink[key] = emptyCacheStats(day);
+  }
+}
+
+/** Drop a model key (or all keys) from the shared sink on reset. */
+function resetLiveTotalsSink(modelKeyPart?: string): void {
+  const sink = liveTotalsSink();
+  if (modelKeyPart === undefined) {
+    for (const key of Object.keys(sink)) delete sink[key];
+    return;
+  }
+  delete sink[modelKeyPart];
+}
 
 function deriveTotalsByModelFromSessionStats(statsByModel: Record<string, CacheStats>): Record<string, CacheStats> {
   const totals: Record<string, CacheStats> = {};
@@ -6961,6 +7027,14 @@ export const __internals_for_tests = {
   buildAdaptiveThinkingCompatSuggestion,
   buildAdaptiveThinkingCompatWarningText,
   appendAdaptiveThinkingCompatAdviceLines,
+  // Process-wide live totals (parent + subagent aggregation)
+  liveTotalsSink,
+  seedLiveTotalsSink,
+  addUsageToLiveTotals,
+  rollOverLiveTotalsSink,
+  resetLiveTotalsSink,
+  isParentSessionInstance,
+  LIVE_TOTALS_GLOBAL_KEY,
 };
 
 export default function (pi: ExtensionAPI) {
@@ -7173,6 +7247,7 @@ export default function (pi: ExtensionAPI) {
     }
     delete cacheStatsTotalsByModel[displayKey];
     delete cacheStatsProcessByModel[displayKey];
+    resetLiveTotalsSink(displayKey);
     pendingDeletedTotalModelKeys.add(displayKey);
     for (const key of Array.from(recentSamplesByModelKey.keys())) {
       if (modelKeyFromSessionScoped(key) === displayKey) recentSamplesByModelKey.delete(key);
@@ -7187,6 +7262,7 @@ export default function (pi: ExtensionAPI) {
     }
     cacheStatsProcessByModel = {};
     cacheStatsTotalsByModel = {};
+    resetLiveTotalsSink();
     replacePersistedTotalsOnNextWrite = true;
     for (const key of Array.from(recentSamplesByModelKey.keys())) {
       if (key.startsWith(prefix)) recentSamplesByModelKey.delete(key);
@@ -7312,6 +7388,8 @@ export default function (pi: ExtensionAPI) {
         changed = true;
       }
     }
+    // Roll the process-wide live sink over the same day boundary.
+    rollOverLiveTotalsSink();
 
     if (changed) {
       lastStatusText = undefined;
@@ -7338,6 +7416,9 @@ export default function (pi: ExtensionAPI) {
       );
       cacheStatsProcessByModel = {};
       cacheStatsTotalsByModel = persisted?.totalsByModel ?? {};
+      // Parent instance: (re)seed the shared sink so the footer's "total"
+      // mode reflects the persisted baseline plus all live subagent traffic.
+      if (isParentSessionInstance(ctx)) seedLiveTotalsSink(cacheStatsTotalsByModel);
       cacheStatsLegacyFamily = persisted?.legacyFamily ?? emptyAllCacheStats();
       lastActualRoutedModel = currentSessionHashSet
         ? persisted?.lastRoutedModelBySession?.[currentSessionHash]
@@ -7357,6 +7438,9 @@ export default function (pi: ExtensionAPI) {
     );
     cacheStatsProcessByModel = {};
     cacheStatsTotalsByModel = persisted?.totalsByModel ?? {};
+    // Parent instance: (re)seed the shared sink so the footer's "total"
+    // mode reflects the persisted baseline plus all live subagent traffic.
+    if (isParentSessionInstance(ctx)) seedLiveTotalsSink(cacheStatsTotalsByModel);
     cacheStatsLegacyFamily = persisted?.legacyFamily ?? emptyAllCacheStats();
     lastActualRoutedModel = currentSessionHashSet
       ? persisted?.lastRoutedModelBySession?.[currentSessionHash]
@@ -7376,6 +7460,10 @@ export default function (pi: ExtensionAPI) {
     let statusText: string | undefined;
     const mode = footerStatsMode();
     const sessionHash = currentSessionHashSet ? currentSessionHash : undefined;
+    // "total" mode source: the process-wide sink (persisted baseline + all
+    // live parent & subagent traffic) for the parent instance; fall back to
+    // per-instance totals otherwise (subagent instances render no footer).
+    const totalsForDisplay = isParentSessionInstance(ctx) ? liveTotalsSink() : cacheStatsTotalsByModel;
 
     if (!adapter && !routedModel && activeIsVirtualRoute) {
       // On model_select (existing footer), keep the existing cache footer
@@ -7388,14 +7476,14 @@ export default function (pi: ExtensionAPI) {
         sessionHash,
         cacheStatsByModel,
         lastActualRoutedModel,
-        cacheStatsTotalsByModel,
+        totalsForDisplay,
         mode,
         cacheStatsProcessByModel,
       ) ?? findBestRouterModelStats(
         mode,
         sessionHash,
         cacheStatsByModel,
-        cacheStatsTotalsByModel,
+        totalsForDisplay,
         cacheStatsProcessByModel,
       );
       if (realEntry) {
@@ -7410,7 +7498,7 @@ export default function (pi: ExtensionAPI) {
       // Footer mode defaults to daily provider/model totals. Users may select
       // current-session counters through persistent command config or the env var.
       const stats = displayModel
-        ? selectFooterStatsForModel(mode, sessionHash, cacheStatsByModel, cacheStatsTotalsByModel, displayModel, cacheStatsProcessByModel)
+        ? selectFooterStatsForModel(mode, sessionHash, cacheStatsByModel, totalsForDisplay, displayModel, cacheStatsProcessByModel)
         : undefined;
       const statsText = formatCacheStats(adapter, stats ?? emptyCacheStats());
       statusText = runtimeOptimizerEnabled ? statsText : `Cache Optimizer disabled · ${statsText}`;
@@ -7866,6 +7954,9 @@ export default function (pi: ExtensionAPI) {
       addUsageToCacheStats(getOrCreateStatsByModelKey(sk), usage);
       addUsageToCacheStats(getOrCreateProcessStatsForModel(statsModel), usage);
       addUsageToCacheStats(getOrCreateTotalStatsForModel(statsModel), usage);
+      // Fold into the process-wide sink so subagent sessions contribute to
+      // the main footer's aggregate totals too.
+      addUsageToLiveTotals(statsModel, usage);
     } else {
       addUsageToCacheStats(getStatsForModel(undefined, adapter), usage);
     }

--- a/tests/live-totals.test.ts
+++ b/tests/live-totals.test.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, test } from "node:test";
+
+import { __internals_for_tests as internals } from "#extension";
+
+/**
+ * Process-wide live totals (parent + subagent aggregation).
+ *
+ * pi-minions runs each subagent as a separate in-process AgentSession that
+ * loads its own copy of this extension. Every instance's `message_end` folds
+ * its usage into a shared process-global sink (globalThis), and the parent
+ * instance's footer "total" mode reads that sink, so the displayed counters
+ * include subagent cache traffic. These tests exercise the sink semantics:
+ * aggregation without double counting, seeding from persisted totals, day
+ * rollover, and reset behavior.
+ */
+
+function currentDay(): string {
+  const now = new Date();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${now.getFullYear()}-${month}-${day}`;
+}
+
+describe("process-wide live totals (parent + subagent aggregation)", () => {
+  const model = { provider: "DIGUA-AI-RESPONS", id: "deepseek-v4-flash" };
+  const key = `${model.provider}/${model.id}`;
+
+  beforeEach(() => {
+    internals.resetLiveTotalsSink();
+  });
+  afterEach(() => {
+    internals.resetLiveTotalsSink();
+  });
+
+  test("folds usage from every instance into one shared sink without double counting", () => {
+    // Persisted baseline seeded at parent session_start.
+    internals.seedLiveTotalsSink({
+      [key]: {
+        day: currentDay(),
+        totalRequests: 500,
+        hitRequests: 500,
+        cachedInputTokens: 110_000_000,
+        cacheWriteInputTokens: 0,
+        totalInputTokens: 110_800_000,
+      },
+    });
+
+    // Parent session live events: 10 requests, 8 hits.
+    for (let i = 0; i < 10; i++) {
+      internals.addUsageToLiveTotals(model, {
+        cacheRead: i < 8 ? 190_000 : 0,
+        cacheWrite: 0,
+        totalInput: 220_000,
+      });
+    }
+    // Subagent A: 6 requests, all hits.
+    for (let i = 0; i < 6; i++) {
+      internals.addUsageToLiveTotals(model, {
+        cacheRead: 233_333,
+        cacheWrite: 0,
+        totalInput: 233_333,
+      });
+    }
+    // Subagent B: 4 requests, 2 hits.
+    for (let i = 0; i < 4; i++) {
+      internals.addUsageToLiveTotals(model, {
+        cacheRead: i < 2 ? 250_000 : 0,
+        cacheWrite: 0,
+        totalInput: 225_000,
+      });
+    }
+
+    const s = internals.liveTotalsSink()[key];
+    assert.equal(s.totalRequests, 520);
+    assert.equal(s.hitRequests, 516);
+    assert.equal(s.cachedInputTokens, 113_419_998);
+    assert.equal(s.totalInputTokens, 115_299_998);
+  });
+
+  test("seed resets the sink to exactly the persisted baseline", () => {
+    internals.addUsageToLiveTotals(model, { cacheRead: 0, cacheWrite: 0, totalInput: 100 });
+    const baseline = {
+      day: currentDay(),
+      totalRequests: 3,
+      hitRequests: 2,
+      cachedInputTokens: 30,
+      cacheWriteInputTokens: 0,
+      totalInputTokens: 60,
+    };
+    internals.seedLiveTotalsSink({ [key]: baseline });
+    assert.deepEqual(internals.liveTotalsSink(), { [key]: baseline });
+  });
+
+  test("rolls stale-day entries over to the current day bucket", () => {
+    internals.seedLiveTotalsSink({
+      [key]: {
+        day: "2000-01-01",
+        totalRequests: 5,
+        hitRequests: 5,
+        cachedInputTokens: 500,
+        cacheWriteInputTokens: 0,
+        totalInputTokens: 500,
+      },
+    });
+    internals.rollOverLiveTotalsSink();
+    const s = internals.liveTotalsSink()[key];
+    assert.equal(s.totalRequests, 0);
+    assert.notEqual(s.day, "2000-01-01");
+    // New-day events accumulate on the fresh bucket.
+    internals.addUsageToLiveTotals(model, { cacheRead: 0, cacheWrite: 0, totalInput: 100 });
+    assert.equal(internals.liveTotalsSink()[key].totalRequests, 1);
+  });
+
+  test("reset removes a single model key or clears the whole sink", () => {
+    internals.addUsageToLiveTotals(model, { cacheRead: 10, cacheWrite: 0, totalInput: 20 });
+    internals.addUsageToLiveTotals({ provider: "p2", id: "m2" }, { cacheRead: 0, cacheWrite: 0, totalInput: 5 });
+
+    internals.resetLiveTotalsSink(key);
+    assert.equal(internals.liveTotalsSink()[key], undefined);
+    assert.ok(internals.liveTotalsSink()["p2/m2"]);
+
+    internals.resetLiveTotalsSink();
+    assert.deepEqual(internals.liveTotalsSink(), {});
+  });
+
+  test("identifies the top-level session instance by PI_SESSION_ID", () => {
+    const previous = process.env.PI_SESSION_ID;
+    try {
+      process.env.PI_SESSION_ID = "parent-session-123";
+      assert.equal(
+        internals.isParentSessionInstance({
+          sessionManager: { getSessionId: () => "parent-session-123" },
+        }),
+        true,
+      );
+      assert.equal(
+        internals.isParentSessionInstance({
+          sessionManager: { getSessionId: () => "minion-session-456" },
+        }),
+        false,
+      );
+      assert.equal(
+        internals.isParentSessionInstance({
+          sessionManager: { getSessionId: () => undefined },
+        }),
+        false,
+      );
+      assert.equal(internals.isParentSessionInstance({}), false);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.PI_SESSION_ID;
+      } else {
+        process.env.PI_SESSION_ID = previous;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## 问题 (Problem)

`pi-minions` 的 `spawn` 把每个 subagent 作为**同一进程内**的独立 `AgentSession` 运行，每个会话会各自加载一份本扩展。footer 的 "DS cache"（默认 total 模式）只由**主会话**实例渲染，它只监听主会话自己的 `message_end`，所以 footer 永远只统计主会话的请求；subagent 的缓存用量被各自记录/持久化，但从不进入主 footer。

## 方案 (Approach)

所有实例共享同一个 Node.js 进程，因此让每个实例在 `message_end` 时把 usage 折叠进一个**进程级共享池**（`globalThis.__piCacheOptimizerLiveTotals__`，按 `provider/id` 分桶）：

- **父会话实例**（通过 `ctx.sessionManager.getSessionId() === process.env.PI_SESSION_ID` 判定）在 `session_start`/restore 时把共享池**重置并播种**为持久化 totals —— 基线权威、reload 不重复计数；
- 主会话 + 所有 subagent 的实时事件在基线上累加；
- footer "total" 模式改读共享池（其余模式行为不变）；
- 跨天滚动、`/cache-optimizer` 重置命令同步清理共享池；
- `PI_SESSION_ID` 缺失或判定失败时回退到原逻辑，无回归。

## 变更 (Changes)

- `index.ts`：新增 7 个模块级辅助函数 + 5 处接线（message_end / restore×2 / publishStatus / rollOver / reset×2），并导出到 `__internals_for_tests`。
- `tests/live-totals.test.ts`：新增 5 个测试（聚合不重复计数、播种、日滚动、重置、父会话判定）。

## 验证 (Verification)

- `npm run typecheck` ✅
- `npm test`：51 通过（46 原有 + 5 新增）✅
- `npm run check`（typecheck + test + diff + pack）✅